### PR TITLE
BUGFIX: fix ENV to GH_TOKEN

### DIFF
--- a/.github/workflows/version-release-with-gittag.yml
+++ b/.github/workflows/version-release-with-gittag.yml
@@ -37,4 +37,4 @@ jobs:
             gh release create $GITTAG --generate-notes
           fi
         env:
-          token: ${{ secrets.regmonkey_edapy_development}}
+          GH_TOKEN: ${{ secrets.regmonkey_edapy_development}}


### PR DESCRIPTION
## BUG

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

## FIX

```
        with:
          token: ${{ secrets.regmonkey_edapy_development}}
```

to 

```
        env:
          GH_TOKEN: ${{ secrets.regmonkey_edapy_development}}
```